### PR TITLE
Service to change gait type

### DIFF
--- a/unitree_nav/src/cmd_processor.cpp
+++ b/unitree_nav/src/cmd_processor.cpp
@@ -156,7 +156,7 @@ public:
     high_cmd_.yaw_speed = 0.0;
 
     // default walking gait is trotting
-    walking_gait = Go1Gait::trot;
+    walking_gait_ = Go1Gait::trot;
 
     RCLCPP_INFO_STREAM(get_logger(), "cmd_processor node started");
   }
@@ -183,7 +183,7 @@ private:
   ros2_unitree_legged_msgs::msg::HighCmd high_cmd_ {};
   bool reset_state_ = false;
   uint8_t reset_counter_ = 0;
-  Go1Gait walking_gait;
+  Go1Gait walking_gait_;
 
   void timer_callback()
   {
@@ -231,7 +231,7 @@ private:
 
     //set mode and gait type
     high_cmd_.mode = to_value(Go1Mode::target_velocity_walking);
-    high_cmd_.gait_type = to_value(walking_gait);
+    high_cmd_.gait_type = to_value(walking_gait_);
   }
 
   void reset_cmd_vel() {
@@ -354,7 +354,7 @@ private:
   ) {
     // check that we are not setting an invalid gait type
     if (request->gait <= 4){
-      walking_gait = static_cast<Go1Gait>(request->gait);
+      walking_gait_ = static_cast<Go1Gait>(request->gait);
     }
   }
 

--- a/unitree_nav/src/cmd_processor.cpp
+++ b/unitree_nav/src/cmd_processor.cpp
@@ -352,7 +352,10 @@ private:
     const std::shared_ptr<unitree_nav_interfaces::srv::SetGait::Request> request,
     std::shared_ptr<unitree_nav_interfaces::srv::SetGait::Response>
   ) {
-    walking_gait = static_cast<Go1Gait>(request->gait);
+    // check that we are not setting an invalid gait type
+    if (request->gait <= 4){
+      walking_gait = static_cast<Go1Gait>(request->gait);
+    }
   }
 
 };

--- a/unitree_nav_interfaces/CMakeLists.txt
+++ b/unitree_nav_interfaces/CMakeLists.txt
@@ -15,6 +15,7 @@ rosidl_generate_interfaces(
   ${PROJECT_NAME}_srv
   "srv/SetBodyRPY.srv"
   "srv/NavToPose.srv"
+  "srv/SetGait.srv"
   LIBRARY_NAME ${PROJECT_NAME}
   DEPENDENCIES
   geometry_msgs

--- a/unitree_nav_interfaces/srv/SetGait.srv
+++ b/unitree_nav_interfaces/srv/SetGait.srv
@@ -1,2 +1,2 @@
-int64 gait    # idle = 0, trot = 1, trot_running = 2, climb_stairs = 3, trot_obstacle = 4
+uint8 gait    # idle = 0, trot = 1, trot_running = 2, climb_stairs = 3, trot_obstacle = 4
 ---

--- a/unitree_nav_interfaces/srv/SetGait.srv
+++ b/unitree_nav_interfaces/srv/SetGait.srv
@@ -1,0 +1,2 @@
+int64 gait    # idle = 0, trot = 1, trot_running = 2, climb_stairs = 3, trot_obstacle = 4
+---

--- a/unitree_nav_interfaces/srv/SetGait.srv
+++ b/unitree_nav_interfaces/srv/SetGait.srv
@@ -1,2 +1,8 @@
-uint8 gait    # idle = 0, trot = 1, trot_running = 2, climb_stairs = 3, trot_obstacle = 4
+uint8 IDLE=0
+uint8 TROT=1
+uint8 TROT_RUNNING=2
+uint8 CLIMB_STAIRS=3
+uint8 TROT_OBSTACLE=4
+
+uint8 gait
 ---


### PR DESCRIPTION
This new custom service allows the user to select the default walking gait used in high level mode for the command processor node. If the service is never called, the default walking gait will be `trot`, which was the case before. This also includes a check that makes sure that the gait requested is valid before setting it.